### PR TITLE
Increase timeout

### DIFF
--- a/src/skip/skip.py
+++ b/src/skip/skip.py
@@ -73,7 +73,7 @@ def send_bundle(b64_encoded_signed_bundle: list[str],
             'id': 1}
 
     # Send post request to RPC with data, get response
-    response = httpx.post(rpc_url, json=data)
+    response = httpx.post(rpc_url, json=data, timeout=10.0)
     
     # Return response
     return response


### PR DESCRIPTION
5s timeout with 6s blocks means sometimes we don't get a response fast enough.